### PR TITLE
Fix: Enable preloading for the 3D room model

### DIFF
--- a/src/sections/HeroModels/Room.jsx
+++ b/src/sections/HeroModels/Room.jsx
@@ -174,5 +174,5 @@ export function Room(props) {
   );
 }
 
-// useGLTF.preload("/models/optimized-room.glb"); 
+useGLTF.preload("/models/optimized-room.glb");
 // comment out for performance


### PR DESCRIPTION
The initial render of the page was laggy because the main 3D model was not being preloaded. This meant that the model was only fetched and parsed when the component was rendered, causing a noticeable delay.

This change re-enables the preloading of the `optimized-room.glb` model by uncommenting the `useGLTF.preload` call in the `Room.jsx` component. This ensures that the model is loaded in the background before it is needed, resulting in a smoother and faster initial render.